### PR TITLE
Feature: Always show "Living Styleguide" navigation item

### DIFF
--- a/src/Common/Presentation/Service/MainNavigationPresentationService.php
+++ b/src/Common/Presentation/Service/MainNavigationPresentationService.php
@@ -121,18 +121,12 @@ final readonly class MainNavigationPresentationService extends AbstractMainNavig
      */
     public function getTertiaryMainNavigationEntries(): array
     {
-        $entries = [];
-
-        if ($this->security->isGranted('ROLE_ADMIN')) {
-            $entries = [
-                $this->generateEntry(
-                    'Living Styleguide',
-                    'webui.living_styleguide.show',
-                )
-            ];
-        }
-
-        return $entries;
+        return [
+            $this->generateEntry(
+                'Living Styleguide',
+                'webui.living_styleguide.show',
+            )
+        ];
     }
 
     public function getBrandLogoHtml(): string


### PR DESCRIPTION
With this change, the "Living Styleguide" is always offered on the navigation, no matter if the current user is logged in or not, and no matter their role.